### PR TITLE
Drawing design

### DIFF
--- a/src/components/Drawing.css
+++ b/src/components/Drawing.css
@@ -31,6 +31,7 @@
 .artworks h3 {
     margin-top: -2rem;
     margin-bottom: 4rem;
+    text-align: center;
     white-space: pre-line;
 }
 

--- a/src/components/Drawing.jsx
+++ b/src/components/Drawing.jsx
@@ -6,21 +6,38 @@ function Drawing() {
   const artworks = [
     {
       imageSrc: '/images/drawing/1.jpg',
-      alt: '1',
+      alt: 'Drawing of a boy piggybacking a girl.',
       description: `
-      1`,
+      Title: Parhelion
+
+      Date Drawn: 2024/07/30
+      
+      Description: 
+      A modern fantasy story about a Gumiho girl, a mythical nine-tailed fox capable of transforming into a human, and a morally flawed boy who, despite being human, possesses special abilities for unknown reasons. Together with their new friends, they solve supernatural incidents caused by special powers and grow through their experiences.
+      `,
     },
     {
       imageSrc: '/images/drawing/2.jpg',
-      alt: '2',
+      alt: 'Drawing of a girl holding a hairpin.',
       description: `
-      2`,
+      Title: Dreaming with You
+
+      Date Drawn: 2024/05/07
+
+      Description:
+      A romantic fantasy story following a boy cursed so that anyone who doesn’t see him for a certain period forgets his existence and a girl who keeps falling in love with him over and over again. Though the story is filled with sorrowful moments, it ultimately focuses on the protagonists finding their way, strengthening their hearts, and moving forward.`,
     },
     {
       imageSrc: '/images/drawing/3.jpg',
-      alt: '3',
+      alt: 'Drawing of a boy and a girl sitting on the rooftop.',
       description: `
-      3`,      
+      Title: Today, as if the Rain Flows
+
+      Date Drawn: 2023/09/08
+
+      Description:
+      A fantasy coming-of-age story about a seemingly ordinary girl falsely accused as the perpetrator of a bullying incident that led to her best friend’s suffering. Just as she is about to make a tragic decision, she is saved by a gumiho boy with supernatural abilities. The boy takes her to a secret world that exists between 12:00 and 12:01 AM, a hidden one-hour dimension exclusive to gumiho. There, he tries to help her rediscover the meaning of life.
+      `,
     },
   ];
 


### PR DESCRIPTION
This PR introduces the Drawing page design, showcasing a portfolio layout for original concept art and illustrations. The page includes a structured gallery displaying three featured artworks, each with an image and a detailed description of its story. Additionally, a section for SNS links (Instagram, Pixiv, ArtStation) is provided for external portfolio access. While this version focuses on the design, interactive features such as buttons and hover effects are not yet implemented.